### PR TITLE
Fix GPS latitude longitude extraction if timezone offset is set in EXIF data

### DIFF
--- a/src/ReadTask.spec.ts
+++ b/src/ReadTask.spec.ts
@@ -40,6 +40,11 @@ describe("Lat/Lon parsing", () => {
       parse({ GPSLongitude: 122.4406148, GPSLongitudeRef: "W" }).GPSLongitude
     ).to.be.closeTo(-122.4406148, 0.00001)
   })
+  it("parses lat lon even if timezone is given", () => {
+    expect(
+      parse({ GPSLongitude: 122.4406148, GPSLongitudeRef: "W", OffsetTime: "+02:00" }).GPSLongitude
+    ).to.be.closeTo(-122.4406148, 0.00001)
+  })
 })
 
 describe("Time zone extraction", () => {

--- a/src/ReadTask.ts
+++ b/src/ReadTask.ts
@@ -106,6 +106,7 @@ export class ReadTask extends ExifToolTask<Tags> {
   }
 
   private parseTags(): Tags {
+    this.extractLatLon()
     this.extractTzOffset()
     Object.keys(this._raw).forEach(key => {
       ;(this.tags as any)[key] = this.parseTag(key, this._raw[key])
@@ -152,7 +153,6 @@ export class ReadTask extends ExifToolTask<Tags> {
       }
     }
     {
-      this.extractLatLon()
       if (!this.invalidLatLon && this.lat != null && this.lon != null) {
         try {
           this.tz = tzlookup(this.lat, this.lon)


### PR DESCRIPTION
Hi,

after updating from exifttool-vendored.js 6.3.0 to the latest version 7.5.0 I encountered files missing the GPS latitude and longitude information.
I found this is caused by existing timezone offset information in the EXIF data of these files.

I added a test for this case which fails on the current master.
The fix just changes the call location of `extractLatLon` so it is called always, not only if there is no timezone information.