### PR TITLE
Added Struct Support

### DIFF
--- a/src/ReadTask.ts
+++ b/src/ReadTask.ts
@@ -57,6 +57,7 @@ export class ReadTask extends ExifToolTask<Tags> {
     const sourceFile = _path.resolve(filename)
     const args = [
       "-json",
+      "-struct", // Return struct tags https://sno.phy.queensu.ca/~phil/exiftool/struct.html
       ...optionalArgs,
       "-coordFormat",
       "%.8f" // Just a float, please, not the default of "22 deg 20' 7.58\" N"
@@ -216,6 +217,7 @@ export class ReadTask extends ExifToolTask<Tags> {
         const t = ExifTime.fromEXIF(value)
         if (t != null) return t
       }
+
       // Trust that ExifTool rendered the value with the correct type in JSON:
       return value
     } catch (e) {

--- a/src/Tags.ts
+++ b/src/Tags.ts
@@ -4441,6 +4441,12 @@ export interface XMPTags {
   /** ☆☆☆☆ ✔ Examples: ["Focus",["Face","Focus"]] */
   RegionType?: string | string[]
   /** ☆☆☆☆   Example: "+7.10" */
+  RegistryId?: {
+    RegItemId?: string
+    RegEntryRole?: string
+    RegOrgId?: string
+  }[]
+  /** ☆☆☆☆   Example: [{ RegItemId: "item 1", RegOrgId: "org 1"}, { RegEntryRole: "role 2", RegOrgId: "org 2"}] */
   RelativeAltitude?: string
   /** ☆☆☆☆   Example: "james robinson taylor" */
   Rights?: string

--- a/src/Tags.ts
+++ b/src/Tags.ts
@@ -4441,7 +4441,7 @@ export interface XMPTags {
   /** ☆☆☆☆ ✔ Examples: ["Focus",["Face","Focus"]] */
   RegionType?: string | string[]
   /** ☆☆☆☆   Example: "+7.10" */
-  RegistryId?: {
+  RegistryID?: {
     RegItemId?: string
     RegEntryRole?: string
     RegOrgId?: string

--- a/src/WriteTask.spec.ts
+++ b/src/WriteTask.spec.ts
@@ -9,7 +9,7 @@ describe("WriteTask", () => {
 
   async function assertRoundTrip(args: {
     tag: keyof WriteTags
-    inputValue: string | number | string[] | { [key: string]: string }[]
+    inputValue: string | number | string[] | { [key: string]: string | number }[]
     expectedValue?: any
     imgName?: string
     args?: string[]

--- a/src/WriteTask.spec.ts
+++ b/src/WriteTask.spec.ts
@@ -108,16 +108,6 @@ describe("WriteTask", () => {
     })
   })
 
-  it("round-trips object/strut input", async () => {
-    return assertRoundTrip({
-      tag: "RegistryId",
-      inputValue: [
-        { RegItemId: "item 1", RegOrgId: "org 1" },
-        { RegEntryRole: "role 2", RegOrgId: "org 2" }
-      ]
-    })
-  })
-
   it("rejects setting to a non-time value", async () => {
     const src = await testImg()
     return expect(
@@ -163,5 +153,17 @@ describe("WriteTask", () => {
     return expect(
       exiftool.write(src, { RandomTag: 123 } as any)
     ).to.be.rejectedWith(/Tag \'RandomTag\' is not defined/)
+  })
+
+  it("Accepts a struct tag", async () => {
+    const struct = [
+      { RegItemId: "item 1", RegOrgId: "org 1" },
+      { RegEntryRole: "role 2", RegOrgId: "org 2" }
+    ]
+    const src = await testImg()
+    await exiftool.write(src, { RegistryID: struct })
+    const tags = await exiftool.read(src)
+    expect(tags.RegistryID).to.eql(struct)
+    return
   })
 })

--- a/src/WriteTask.spec.ts
+++ b/src/WriteTask.spec.ts
@@ -9,7 +9,7 @@ describe("WriteTask", () => {
 
   async function assertRoundTrip(args: {
     tag: keyof WriteTags
-    inputValue: string | number | string[]
+    inputValue: string | number | string[] | { [key: string]: string }[]
     expectedValue?: any
     imgName?: string
     args?: string[]
@@ -105,6 +105,16 @@ describe("WriteTask", () => {
     return assertRoundTrip({
       tag: "Keywords",
       inputValue: ["one", "two", "three"]
+    })
+  })
+
+  it("round-trips object/strut input", async () => {
+    return assertRoundTrip({
+      tag: "RegistryId",
+      inputValue: [
+        { RegItemId: "item 1", RegOrgId: "org 1" },
+        { RegEntryRole: "role 2", RegOrgId: "org 2" }
+      ]
     })
   })
 

--- a/src/WriteTask.ts
+++ b/src/WriteTask.ts
@@ -59,12 +59,12 @@ export class WriteTask extends ExifToolTask<void> {
                   }
                 )
 
-                return `{ ${structKeyValuePairs} }`
+                return `{${structKeyValuePairs}}`
               })
               .join(", ")
 
             // EG. ArtworkOrObject: [{ AOCreator=badger, AOTitle=a title }, { AOTitle=another one }]
-            args.push(`${key}=[${structs}]`)
+            args.push(`-${key}=[${structs}]`)
           }
         } else {
           // Its a string type

--- a/src/WriteTask.ts
+++ b/src/WriteTask.ts
@@ -49,7 +49,7 @@ export class WriteTask extends ExifToolTask<void> {
 
             // Ultimately this would have to be a recursive function as in theory structs can be
             // nested in one another, and even inlucde arrays etc. However in this basic implementation
-            // they just support simple strings as values
+            // just support simple strings as values
             const structs = (value as { [key: string]: string }[])
               .map(struct => {
                 const structKeyValuePairs = Object.keys(struct).map(

--- a/src/WriteTask.ts
+++ b/src/WriteTask.ts
@@ -3,7 +3,6 @@ import * as _path from "path"
 import { Tags, WriteTags } from "./ExifTool"
 import { ExifToolTask } from "./ExifToolTask"
 import { htmlEncode } from "./String"
-import { isString } from "util"
 
 const successRE = /1 image files? updated/
 
@@ -39,7 +38,7 @@ export class WriteTask extends ExifToolTask<void> {
       .forEach((key: keyof Tags) => {
         const value = tags[key]
         if (Array.isArray(value)) {
-          if ((value as any[]).every(entry => isString(entry))) {
+          if ((value as any[]).every(entry => typeof entry === "string")) {
             // Its a simple array type
             ;(value as any[]).forEach(ea => args.push(`-${key}=${enc(ea)}`))
           }
@@ -50,11 +49,11 @@ export class WriteTask extends ExifToolTask<void> {
             // Ultimately this would have to be a recursive function as in theory structs can be
             // nested in one another, and even inlucde arrays etc. However in this basic implementation
             // just support simple strings as values
-            const structs = (value as { [key: string]: string }[])
+            const structs = (value as { [key: string]: string | number }[])
               .map(struct => {
                 const structKeyValuePairs = Object.keys(struct).map(
                   structKey => {
-                    const structValue: string = struct[structKey]
+                    const structValue: string | number = struct[structKey]
                     return `${structKey}=${enc(structValue)}`
                   }
                 )


### PR DESCRIPTION
Hey Matthew,

So I've added struct support. Turns out we didn't need to do any major change to the way we read from Exiftool, just adding the `-struct` argument seemed to do the trick. 

There's a couple of things to bear in mind:
1. I manually updated `Tags.ts` to include a struct type definition for the one I was interested in. I'm not sure how to go about having this automatically parsed like you do in `mktags`, perhaps you could shed some light on that? I'm not sure how often you regenerate that file, is putting it in manually an option for now?
2. Currently the struct writing is a basic implementation that only writes strings, one level deep. From what I can tell this will cover the majority of use cases, but from what I understand Exiftool actually supports deeply nested structs, so might be something we could think about supporting in the future.

Let me know if there's any problems with this or if I've done some bad Typescript again!